### PR TITLE
Support Ruby 3.2 and above

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ plugins:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/gir_ffi-gtk4.gemspec
+++ b/gir_ffi-gtk4.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "http://www.github.com/mvz/gir_ffi-gtk4"
 
   spec.license = "LGPL-2.1+"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/gir_ffi-gtk4"

--- a/lib/gir_ffi-gtk4/dialog.rb
+++ b/lib/gir_ffi-gtk4/dialog.rb
@@ -13,9 +13,9 @@ module Gtk
 
   # Overrides for GtkDialog
   class Dialog
-    def self.new_with_buttons(*args)
+    def self.new_with_buttons(*)
       obj = allocate
-      obj.send :initialize_with_buttons, *args
+      obj.send(:initialize_with_buttons, *)
       obj
     end
 

--- a/lib/gir_ffi-gtk4/file_chooser_dialog.rb
+++ b/lib/gir_ffi-gtk4/file_chooser_dialog.rb
@@ -13,9 +13,9 @@ module Gtk
 
   # Overrides for GtkFileChooserDialog
   class FileChooserDialog
-    def self.new(*args)
+    def self.new(*)
       obj = allocate
-      obj.send :initialize, *args
+      obj.send(:initialize, *)
       obj
     end
 

--- a/lib/gir_ffi-gtk4/tree_view_column.rb
+++ b/lib/gir_ffi-gtk4/tree_view_column.rb
@@ -6,9 +6,9 @@ module Gtk
   class TreeViewColumn
     setup_method! :new
 
-    def self.new_with_attributes(*args)
+    def self.new_with_attributes(*)
       obj = allocate
-      obj.send :initialize_with_attributes, *args
+      obj.send(:initialize_with_attributes, *)
       obj
     end
 


### PR DESCRIPTION
- **Require Ruby 3.2 or higher**
- **Bump RuboCop target ruby version**
- **Autocorrect Style/ArgumentsForwarding**
- **Remove Ruby 3.1 from the CI matrix**
